### PR TITLE
[Body/Link.cpp] fix removeChild

### DIFF
--- a/src/Body/Link.cpp
+++ b/src/Body/Link.cpp
@@ -230,12 +230,12 @@ bool Link::removeChild(Link* childToRemove)
     while(link){
         if(link == childToRemove){
             childToRemove->parent_ = nullptr;
-            childToRemove->sibling_ = nullptr;
             if(prevSibling){
                 prevSibling->sibling_ = link->sibling_;
             } else {
                 child_ = link->sibling_;
             }
+            childToRemove->sibling_ = nullptr;
             childToRemove->setBody(0);
             return true;
         }


### PR DESCRIPTION
This Pull Request fixes a bug in `Link::removeChild`.
`Link::removeChild` cannot deal with `sibling_` information correctly because `sibling_` is set to `nullptr` before dealt with.
