### PR TITLE
[CI] Add simple build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: CI of choreonoid
+
+on:
+  push:
+    paths-ignore:
+      # Changes to those files don't mandate running CI
+      - "debian/**"
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
+        build-type: [RelWithDebInfo]
+        compiler: [gcc, clang]
+        exclude:
+          # Only default compiler on macos-latest
+          - os: macos-latest
+            compiler: clang
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      uses: jrl-umi3218/github-actions/install-dependencies@master
+      if: matrix.build-type != 'script'
+      with:
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}
+        ubuntu: |
+          apt: doxygen doxygen-latex graphviz libboost-all-dev libeigen3-dev libz-dev libjpeg-dev libpng-dev libglew-dev libxfixes-dev libyaml-dev qt5-default libqt5svg5-dev libqt5x11extras5-dev libode-dev libcos4-dev python2.7-dev python3-dev uuid-dev gettext libyaml-dev pkg-config
+        macos: |
+          brew: eigen boost doxygen zlib jpeg libpng glew libxfixes libyaml pkg-config libtool
+    - name: Build and test
+      uses: jrl-umi3218/github-actions/build-cmake-project@master
+      with:
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}


### PR DESCRIPTION
Following our discussion about CI in the issues, this PR provides a simple example of how it could be set-up using github actions. 

As-is, it checks compilation using the default options for:
- Ubuntu 18.04/20.04 with clang/gcc
- Macos (latest) with gcc

Right now building only passes for Ubuntu 18.04/20.04 with gcc. 
- For MacOs there seems to be issues with the way dlopen is found. 
- For ubuntu+clang there still seems to be some issues.

You won't see the actions result on the official repository for now as actions are not currently enabled. You can check the result on my fork here: https://github.com/arntanguy/choreonoid-1/actions

If you want to experiment with it, feel free to push to this branch. We can easily add other variations of building (such as c++11/14, enabling some compilation options, etc).