### PR TITLE
[include] Add cnoid/GLVisionSimulatorItem

### DIFF
--- a/include/cnoid/GLVisionSimulatorItem
+++ b/include/cnoid/GLVisionSimulatorItem
@@ -1,0 +1,1 @@
+#include "src/BodyPlugin/GLVisionSimulatorItem.h"


### PR DESCRIPTION
This PR add an include file for GLVisionSimulatorItem.
I want to use `cnoid.BodyPlugin` with cnoid-boost-python, but it need to include `GLVisionSImulatorItem.h`.