### PR TITLE
[Util/EigenUtil.l] fix instability of omegaFromRot

### DIFF
--- a/src/Util/EigenUtil.cpp
+++ b/src/Util/EigenUtil.cpp
@@ -180,10 +180,13 @@ Vector3 omegaFromRot(const Matrix3& R)
 {
     double alpha = (R(0,0) + R(1,1) + R(2,2) - 1.0) / 2.0;
 
-    if(fabs(alpha - 1.0) < 1.0e-6) {   //th=0,2PI;
+    if(alpha > 1.0 - 1.0e-6) {   //th=0,2PI;
         return Vector3::Zero();
 
     } else {
+        if (alpha < -1.0) {
+            alpha = -1.0;
+        }
         double th = acos(alpha);
         double s = sin(th);
 


### PR DESCRIPTION
This Pull Request fixes instability of `omegaFromRot`.
`omegaFromRot` sometimes returns `[nan, nan, nan]`.

If `alpha < 1.0` or `alpha > 1.0`, `acos()` returns `nan`. `alpha` is not always `-1.0 <= alpha <= 1.0` because of numerical error.
https://github.com/choreonoid/choreonoid/blob/77e3c0da5cec7a0046fff5c5d7e68ccc208e5364/src/Util/EigenUtil.cpp#L187


