### PR TITLE
[BUG_FIX] fix to install AssimpSceneLoader.h

### DIFF
--- a/src/AssimpSceneLoader/CMakeLists.txt
+++ b/src/AssimpSceneLoader/CMakeLists.txt
@@ -1,5 +1,9 @@
 if(ENABLE_ASSIMP)
-  choreonoid_add_library(CnoidAssimpSceneLoader SHARED AssimpSceneLoader.cpp)
+  set(headers
+    AssimpSceneLoader.h
+    exportdecl.h
+    )
+  choreonoid_add_library(CnoidAssimpSceneLoader SHARED AssimpSceneLoader.cpp HEADERS ${headers})
   if(ASSIMP_USE_IMPORTED_LIBRARY)
     target_link_libraries(CnoidAssimpSceneLoader CnoidUtil assimp::assimp)
   else()


### PR DESCRIPTION
This PR add an include file for AssimpSceneLoader.h.
Without this PR, "cnoid/src/AssimpSceneLoader/AssimpSceneLoader.h" is not installed, even though "cnoid/AssimpSceneLoader" includes it