### PR TITLE
Provide an alternative std::clamp implementation for c++<17

### DIFF
--- a/include/cnoid/stdx/clamp
+++ b/include/cnoid/stdx/clamp
@@ -1,0 +1,21 @@
+#pragma once
+
+#if __cplusplus > 201703L
+#include <algorithm>
+#else
+namespace std {
+/** Clamp a value in a given interval.
+ *
+ * \param value Value to clamp.
+ * \param lower Lower bound.
+ * \param upper Upper bound.
+ *
+ * \returns clamped value
+ */
+template<typename T>
+constexpr const T clamp(const T& value, const T& lower, const T& upper)
+{
+    return std::max(lower, std::min(value, upper));
+}
+}  // namespace std
+#endif

--- a/include/cnoid/stdx/clamp
+++ b/include/cnoid/stdx/clamp
@@ -1,6 +1,6 @@
 #pragma once
 
-#if __cplusplus > 201703L
+#if __cplusplus >= 201703L
 #include <algorithm>
 #else
 namespace std {

--- a/src/Body/ForwardDynamicsABM.cpp
+++ b/src/Body/ForwardDynamicsABM.cpp
@@ -7,6 +7,7 @@
 #include "DyBody.h"
 #include <cnoid/EigenUtil>
 #include <algorithm>
+#include <cnoid/stdx/clamp>
 
 using std::clamp;
 using namespace cnoid;


### PR DESCRIPTION
This PR fixes build using C++<17.
The issue is that there is no `std::clamp` implementation prior to this c++ standard.