### PR TITLE
Prevent multiple creation of targets

### DIFF
--- a/cmake/ChoreonoidConfig.cmake.in
+++ b/cmake/ChoreonoidConfig.cmake.in
@@ -1,23 +1,25 @@
 # Use the following variables to compile and link against Choreonoid:
-# CHOREONOID_FOUND                 - True if Choreonoid was found on your system
-# CHOREONOID_VERSION_STRING        - A human-readable string containing the version
-# CHOREONOID_VERSION_MAJOR         - The major version of Choreonoid
-# CHOREONOID_VERSION_MINOR         - The minor version of Choreonoid
-# CHOREONOID_VERSION_PATCH         - The patch version of Choreonoid
-# CHOREONOID_ROOT_DIR              - The base directory of Choreonoid
-# CHOREONOID_CXX_STANDARD          - The c++ standard version used to build Choreonoid (11, 14, or 17)
-# CHOREONOID_COMPILE_DEFINITIONS   - Definitions needed to build with Choreonoid
-# CHOREONOID_INCLUDE_DIRS          - List of directories of Choreonoid and it's dependencies
-# CHOREONOID_LIBRARY_DIRS          - List of directories of Choreonoid and it's dependencies
-# CHOREONOID_UTIL_LIBRARIES        - List of libraries to use the CnoidUtil libary
-# CHOREONOID_BASE_LIBRARIES        - List of libraries to use the CnoidBase libary
-# CHOREONOID_BODY_LIBRARIES        - List of libraries to use the CnoidBody libary
-# CHOREONOID_BODY_PLUGIN_LIBRARIES - List of libraries to use the CnoidBody libary
-# CHOREONOID_SKIP_QT_CONFIG        - Set true in advance to disable the Qt library setup
+# choreonoid_FOUND                 - True if Choreonoid was found on your system
+# choreonoid_VERSION_STRING        - A human-readable string containing the version
+# choreonoid_VERSION_MAJOR         - The major version of Choreonoid
+# choreonoid_VERSION_MINOR         - The minor version of Choreonoid
+# choreonoid_VERSION_PATCH         - The patch version of Choreonoid
+# choreonoid_ROOT_DIR              - The base directory of Choreonoid
+# choreonoid_CXX_STANDARD          - The c++ standard version used to build Choreonoid (11, 14, or 17)
+# choreonoid_COMPILE_DEFINITIONS   - Definitions needed to build with Choreonoid
+# choreonoid_INCLUDE_DIRS          - List of directories of Choreonoid and it's dependencies
+# choreonoid_LIBRARY_DIRS          - List of directories of Choreonoid and it's dependencies
+# choreonoid_UTIL_LIBRARIES        - List of libraries to use the CnoidUtil libary
+# choreonoid_BASE_LIBRARIES        - List of libraries to use the CnoidBase libary
+# choreonoid_BODY_LIBRARIES        - List of libraries to use the CnoidBody libary
+# choreonoid_BODY_PLUGIN_LIBRARIES - List of libraries to use the CnoidBody libary
+# choreonoid_SKIP_QT_CONFIG        - Set true in advance to disable the Qt library setup
 #
 # Set the following variables to change the behaviour of the functions provided by this module
 # CHOREONOID_INSTALL_SDK      - Set on if you want to install SDK files
 
+
+if(NOT TARGET Choreonoid::CnoidBase)
 set(CHOREONOID_ROOT_DIR @CMAKE_INSTALL_PREFIX@)
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.7.0)
@@ -193,3 +195,4 @@ file(GLOB extmodules LIST_DIRECTORIES false "${CMAKE_CURRENT_LIST_DIR}/ext/*.cma
 foreach(module ${extmodules})
   include(${module})
 endforeach()
+endif()


### PR DESCRIPTION
The current `ChoreonoidConfig.cmake` file will create targets regardless of whether they already exist, which is forbidden by cmake. This can arise if the user calls `find_package(choreonoid)` multiple times in his own `CMakeLists`. This prevents against it by checking whether the `Choreonoid::CnoidBase` target was already found.

Ideally the `ChoreonoidConfig.cmake` should properly handle finding only sub-components of choreonoid (currently it creates all targets regardless of the desired components list), e.g.

```cmake
find_package(Choreonoid REQUIRED COMPONENTS CnoidBase)
```