### PR TITLE
bug fix of Windows implementation of MediaPlugin

### DIFF
--- a/src/MediaPlugin/DSMediaView.cpp
+++ b/src/MediaPlugin/DSMediaView.cpp
@@ -217,24 +217,19 @@ DSMediaViewImpl::~DSMediaViewImpl()
 
 }
 
-
-/*
-  bool DSMediaView::event(QEvent* event)
-  {
-  if(TRACE_FUNCTIONS){
-  cout << "DSMediaView::event()" << endl;
-  }
+bool DSMediaView::event(QEvent* event){
+    if(TRACE_FUNCTIONS){
+        cout << "DSMediaView::event()" << endl;
+    }
     
-  if(event->type() == QEvent::WinIdChange){
-  impl->onWindowIdChanged();
-  return true;
-  }
-  //return QWidget::event(event);
+    if(event->type() == QEvent::WinIdChange){
+        impl->onWindowIdChanged();
+        return true;
+    }
+    return QWidget::event(event);
 
-  return false;
-  }
-*/
-
+    //return false;
+}
 
 namespace {
     
@@ -453,23 +448,30 @@ void DSMediaViewImpl::load()
         if(!bCanSeek){
             mv->putln(_("This media file is not able to seek!"));
         }
-
+        
         // Query for video interfaces, which may not be relevant for audio files
         EIF(graphBuilder->QueryInterface(IID_IVideoWindow, (void**)&videoWindow));
         EIF(graphBuilder->QueryInterface(IID_IBasicVideo, (void**)&basicVideo));
 
         // Have the graph signal event via window callbacks for performance
         EIF(mediaEvent->SetNotifyWindow((OAHWND)hwnd, WM_DSHOW_NOTIFY, 0));
+
+        try{
+            // Setup the video window
+            EIF(videoWindow->put_Owner((OAHWND)hwnd));
+            EIF(videoWindow->put_WindowStyle(WS_CHILD | WS_CLIPSIBLINGS));
+
+            EIF(adjustVideoWindow());
+
+            EIF(videoWindow->SetWindowForeground(OATRUE));
+            EIF(videoWindow->put_Visible(OATRUE));
+        }
+        catch (const DSException& ex){
+            // comes here if loaded file is pure audio (e.g. wav file) and the filter graph has no video renderer attached to it
+            videoWindow = nullptr;
+            basicVideo = nullptr;
+        }
         
-        // Setup the video window
-        EIF(videoWindow->put_Owner((OAHWND)hwnd));
-        EIF(videoWindow->put_WindowStyle(WS_CHILD | WS_CLIPSIBLINGS));
-
-        EIF(adjustVideoWindow());
-
-        EIF(videoWindow->SetWindowForeground(OATRUE));
-        EIF(videoWindow->put_Visible(OATRUE));
-
         connectTimeBarSignals();
 
         seekMedia(TimeBar::instance()->time());

--- a/src/MediaPlugin/DSMediaView.h
+++ b/src/MediaPlugin/DSMediaView.h
@@ -22,7 +22,7 @@ public:
     virtual bool restoreState(const Archive& archive);
 
 protected:
-    //virtual bool event(QEvent* event);
+    virtual bool event(QEvent* event);
     virtual void resizeEvent(QResizeEvent* event);
     virtual void paintEvent(QPaintEvent* event);
     virtual QPaintEngine* paintEngine () const;


### PR DESCRIPTION
wavなどをMediaItemで指定した際にFilterGraphが内部でVideoRendererを生成しないためにVideoWindowが例外を投げ，その後の処理がスキップされていました．例外が出ても必要な処理をスキップしないように修正しました．
wavファイルでも再生されることを確認しました．