### PR TITLE
Changed the package.xml configuration for building with ROS 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,8 @@
   <url type="repository">https://github.com/choreonoid/choreonoid/</url>
   <url type="bugtracker">https://github.com/choreonoid/choreonoid/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <depend>boost</depend>
   <build_export_depend>eigen</build_export_depend>


### PR DESCRIPTION
The package.xml occurs an error with rosdep and ROS 2 like below.

```bash
$ rosdep install -iy --from-paths src
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
choreonoid: Cannot locate rosdep definition for [catkin]
```

This error can be ignored and is not fatal, but this pull request fixes it.