### PR TITLE
Fix toVectorX_ to ignore last spaces

### DIFF
--- a/src/Util/EigenUtil.cpp
+++ b/src/Util/EigenUtil.cpp
@@ -250,7 +250,7 @@ static bool toVectorX_(const std::string& s, VectorType& out_v)
         nptr++;
     }
     // returns true if the number of elements matches the vector size
-    return endptr == nptr;
+    return nptr == s.c_str() + s.size();
 }
 
 


### PR DESCRIPTION
When I load the URDF file below, I got the following error.
```
error: origin rpy is written in invalid format in reading joint "JOINT0".
  -> failed.
```

```xml
<?xml version="1.0"?>
<robot name="MyRobot"
       xmlns:xi="http://www.w3.org/2001/XInclude">
  <link name="BODY">
    <visual>
      <geometry>
        <box size="0.2 0.2 0.2" />
      </geometry>
    </visual>
    <collision>
      <geometry>
        <box size="0.2 0.2 0.2" />
      </geometry>
    </collision>
    <inertial>
      <mass value="10.0" />
      <inertia ixx="0.1" ixy="0.0" ixz="0.0" iyy="0.1" iyz="0.0" izz="0.1"/>
    </inertial>
  </link>
  <link name="LINK0">
    <visual>
      <geometry>
        <box size="0.2 0.2 0.2" />
      </geometry>
    </visual>
    <collision>
      <geometry>
        <box size="0.2 0.2 0.2" />
      </geometry>
    </collision>
    <inertial>
      <mass value="10.0" />
      <inertia ixx="0.1" ixy="0.0" ixz="0.0" iyy="0.1" iyz="0.0" izz="0.1"/>
    </inertial>
  </link>
  <joint name="JOINT0" type="revolute">
    <parent link="BODY"/>
    <child  link="LINK0"/>
    <origin xyz="0.0 0.0 0.2" rpy="0.0 0.0 0.0 "/>
    <axis   xyz="0 0 1"/>
    <limit lower="-1.0" upper="1.0" effort="1.0" velocity="1.0" />
    <dynamics damping="0.2" friction="0" />
  </joint>
</robot>
```

When I remove  the last space of rpy field, the model is successfully loaded.
```diff
- <origin xyz="0.0 0.0 0.2" rpy="0.0 0.0 0.0 "/>
+ <origin xyz="0.0 0.0 0.2" rpy="0.0 0.0 0.0"/>
```

This pull request fixes `toVectorX_` function to ignore the last spaces.

URDF files generated by `collada_urdf` always have spaces after rpy.
https://github.com/ros/collada_urdf/blob/461d6016d11966e8cca27511712f5fdafa263e93/collada_urdf/src/collada_to_urdf.cpp#L440