### PR TITLE
[CMake] Set CHOREONOID_USE_PYTHON2 variable in config file

### DIFF
--- a/cmake/ChoreonoidConfig.cmake.in
+++ b/cmake/ChoreonoidConfig.cmake.in
@@ -49,6 +49,7 @@ set(CHOREONOID_COMPILE_DEFINITIONS "@compile_definitions@")
 set(CHOREONOID_DEFAULT_FVISIBILITY_HIDDEN @CHOREONOID_DEFAULT_FVISIBILITY_HIDDEN@)
 set(CHOREONOID_INCLUDE_DIRS "@include_dirs@")
 set(CHOREONOID_LIBRARY_DIRS "@library_dirs@")
+set(CHOREONOID_USE_PYTHON2 @CNOID_USE_PYTHON2@)
 
 if(@has_boost_libs_for_util_libs@)
   find_package(Boost @boost_version@ EXACT COMPONENTS @boost_components_for_util_libs@)


### PR DESCRIPTION
In order for the python version to be consistent over chorenoid and cnoid files, I added this setter to know which python version has been selected for choreonoid. 