### PR TITLE
fix readGeometryTag function in Sphere type for urdf

### DIFF
--- a/src/URDFBodyLoader/URDFBodyLoader.cpp
+++ b/src/URDFBodyLoader/URDFBodyLoader.cpp
@@ -681,6 +681,7 @@ bool URDFBodyLoader::Impl::readGeometryTag(const xml_node& geometryNode, ShapeDe
         description.length = geometryNode.child(CYLINDER).attribute(LENGTH).as_double();
         
     } else if (!geometryNode.child(SPHERE).empty()) {
+        description.shapeType = ShapeDescription::Sphere;
         if (geometryNode.child(SPHERE).attribute(RADIUS).empty()) {
             os() << "Error: sphere radius is not defined";
             return false;


### PR DESCRIPTION
When I loaded the URDF file below, I got the sphere was not drawn.
```urdf
<robot name="robot">
  <link name="link">
    <visual>
      <origin xyz="0 0 0.25"/>
      <geometry>
        <sphere radius="0.1"/>
      </geometry>
      <material>
        <color rgba="1., 0.2, 0.2, 1.0" />
      </material>
    </visual>
  </link>
</robot>
```
In function `URDFBodyLoader::Impl::readGeometryTag`  in the case of sphere shape, `description.shapeType` isn't updated.
When I fix the `URDFBodyLoader::Impl::readGeometryTag` function,  the model is successfully loaded.