### PR TITLE
FIX: initialize Isometry3 variable with Isometry3::identity()

### DIFF
--- a/src/Base/SceneWidget.cpp
+++ b/src/Base/SceneWidget.cpp
@@ -1991,7 +1991,7 @@ Isometry3 SceneWidget::Impl::getNormalizedCameraTransform(const Isometry3& T)
     }
     y = z.cross(x);
         
-    Isometry3 N;
+    Isometry3 N(Isometry3::Identity());
     N.linear() << x, y, z;
     N.translation() = T.translation();
     return N;
@@ -2064,7 +2064,7 @@ void SceneWidget::Impl::dragViewRotation()
     const double dx = latestEvent.x() - orgMouseX;
     const double dy = latestEvent.y() - orgMouseY;
 
-    Isometry3 R;
+    Isometry3 R(Isometry3::Identity());
     if(isCameraRollRistricted){
         Vector3 up = Vector3::Unit(verticalAxis);
         R = AngleAxis(-dx * dragAngleRatio, up) *

--- a/src/Util/SceneCameras.cpp
+++ b/src/Util/SceneCameras.cpp
@@ -31,7 +31,7 @@ Isometry3 SgCamera::positionLookingFor(const Vector3& eye, const Vector3& direct
     Vector3 d = direction.normalized();
     Vector3 c = d.cross(up).normalized();
     Vector3 u = c.cross(d);
-    Isometry3 C;
+    Isometry3 C(Isometry3::Identity());
     C.linear() << c, u, -d;
     C.translation() = eye;
     return C;


### PR DESCRIPTION
Isometry3 should be initialized.
If not initialized, indefined values are appeared in a matrix.