### PR TITLE
Install URDFBodyLoader/exportdecl.h

### DIFF
--- a/src/URDFBodyLoader/CMakeLists.txt
+++ b/src/URDFBodyLoader/CMakeLists.txt
@@ -8,5 +8,5 @@ if(PUGIXML_STATIC_LIBRARY_DIRS)
 endif()
 
 make_gettext_mofiles(CnoidURDFBodyLoader mofiles)
-choreonoid_add_library(CnoidURDFBodyLoader SHARED URDFBodyLoader.cpp HEADERS URDFBodyLoader.h)
+choreonoid_add_library(CnoidURDFBodyLoader SHARED URDFBodyLoader.cpp HEADERS URDFBodyLoader.h exportdecl.h)
 target_link_libraries(CnoidURDFBodyLoader PUBLIC CnoidBody PRIVATE ${PUGIXML_STATIC_LIBRARIES})


### PR DESCRIPTION
To use URDFBodyLoader from an external package, exportdecl.h is required to be installed.