### PR TITLE
Fix issues with loading and rendering the PR2 URDF model

### DIFF
--- a/src/GLSceneRenderer/GLSLSceneRenderer.cpp
+++ b/src/GLSceneRenderer/GLSLSceneRenderer.cpp
@@ -2793,6 +2793,11 @@ bool GLSLSceneRenderer::Impl::loadTextureImage(TextureResource* resource, const 
     } else {
         // NPOT (Non-Power-Of-Two) textures are fully supported in OpenGL 3.3+
         glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, image.pixels());
+        if(format == GL_RED){
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+        }
         resource->isLoaded = true;
         resource->width = width;
         resource->height = height;

--- a/src/URDFBodyLoader/URDFBodyLoader.cpp
+++ b/src/URDFBodyLoader/URDFBodyLoader.cpp
@@ -829,7 +829,9 @@ void URDFBodyLoader::Impl::setMaterialToAllShapeNodes(SgNode* node, SgMaterial* 
             setMaterialToAllShapeNodes(child, material);
         }
     } else if (auto shape = dynamic_cast<SgShape*>(node)) {
-        shape->setMaterial(material);
+        if (!shape->material()) {
+            shape->setMaterial(material);
+        }
     }
 }
 

--- a/thirdparty/xacro-1.14.10/src/xacro/substitution_args.py
+++ b/thirdparty/xacro-1.14.10/src/xacro/substitution_args.py
@@ -111,6 +111,8 @@ def _eval_find(pkg):
     for package_path in package_paths:
         if package_path.endswith('/' + pkg):
             return package_path
+        if os.path.exists(package_path + '/' + pkg):
+            return package_path + '/' + pkg
 
     raise ResourceNotFound
 


### PR DESCRIPTION
This PR provides several fixes to ensure that the PR2 URDF model [link](https://github.com/PR2/pr2_common/blob/melodic-devel/pr2_description/robots/pr2.urdf.xacro) can be loaded and rendered correctly in Choreonoid.

### 1st Commit: Fix package path resolution of xacro 
In a ROS Noetic environment, installing the PR2 model via `sudo apt install ros-noetic-pr2-description` and attempting to load it in Choreonoid resulted in the following error:

<img width="991" height="667" alt="Screenshot from 2026-04-17 13-46-46" src="https://github.com/user-attachments/assets/69084e80-681d-4f14-8d14-126cabbacf6f" />

**Terminal Output:**
```shell
$ echo $ROS_PACKAGE_PATH
/opt/ros/noetic/share
$ ls /opt/ros/noetic/share/ | grep pr2_description
pr2_description
$ choreonoid
resource not found:
when processing file: /opt/ros/noetic/share/pr2_description/robots/pr2.urdf.xacro
```

**Cause:**
The xacro processor failed to locate packages residing under `/opt/ros/noetic/share`. This commit fixes the package path resolution logic.

**After 1st Commit**
<img width="775" height="665" alt="Screenshot from 2026-04-17 13-23-50" src="https://github.com/user-attachments/assets/01538a67-366b-4bec-83d3-3cbe1367c0d0" />

### 2nd Commit: Fix grayscale texture rendering (OpenGL Swizzle)
After fixing the first issue, the PR2 model could be loaded, but its colors were not rendered correctly (as shown in the above image). 

One of the causes is that the PR2 model uses grayscale textures (e.g., [l_finger_color.png](https://github.com/PR2/pr2_common/blob/melodic-devel/pr2_description/meshes/gripper_v0/l_finger_color.png)) from dae file (e.g., [l_finger.dae](https://github.com/PR2/pr2_common/blob/9a8e4fbcf66523ca14faf651c23513ee1ac29ccb/pr2_description/meshes/gripper_v0/l_finger.dae#L98) ). There was a bug where these grayscale images were incorrectly displayed as "red and white" images. 

**Fix:**
Implemented OpenGL texture swizzle settings to ensure grayscale data is correctly mapped to the RGB channels.

**After 2nd Commit**
<img width="761" height="674" alt="Screenshot from 2026-04-17 15-33-16" src="https://github.com/user-attachments/assets/75cc186f-9fba-4897-96b2-0d7afebc7630" />

### 3rd Commit: Implicit URDF material priority

The second reason for the incorrect coloring involves an implicit URDF specification (not explicitly documented in the official spec).

**Implicit Specification:**
The `<material>` tag under `<link>/<visual>` should be ignored if the mesh specified in the `<geometry>` tag already contains its own color information. 

This behavior is standard in rviz (see the relevant logic in rviz here: [robot_link.cpp#L666-L669](https://github.com/ros-visualization/rviz/blob/26bbf0a1819253d7515c096a71f1f5cd58f88748/src/rviz/robot/robot_link.cpp#L666-L669)). 
<img width="976" height="937" alt="Screenshot from 2026-04-17 15-44-45" src="https://github.com/user-attachments/assets/6b89c092-87de-40f1-a451-1e47fc8b9dee" />


This commit implements the same logic to ensure visual consistency.

**After 3rd Commit**
<img width="775" height="665" alt="Screenshot from 2026-04-17 13-23-52" src="https://github.com/user-attachments/assets/03e842b7-d43c-4ecd-a646-e0119288fcd7" />

Regarding the 3rd Commit, it might be better not to adopt it, as there isn't a unified specification across all ROS tools.